### PR TITLE
php: configure php memory_limit settings as recommended by Nextcloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,41 @@ Basic example playbook:
 Role parameters
 ----------------
 
-| Variable                | Default    | Type            | Description                                                                                                            |
-| ----------------------- | :------:   | :-------------: | ------------                                                                                                           |
-| `nextcloud_version`     | `18.0.4`   | `string`        | Which nextcloud version to install                                                                                     |
-| `nextcloud_destination` | `/var/www` | `string`        | Where to install Nextcloud (will be installed in "{{ nextcloud_destination}}/nextcloud/" directory on your filesystem) |
-| `nextcloud_dir_user`    | `www-data` | `string`        | Which unix user should own the installed directory                                                                     |
-| `nextcloud_dir_group`   | `www-data` | `string`        | Which unix group should own the installed directory                                                                    |
+| Variable                     | Default    | Type            | Description                                                                                                            |
+| -----------------------      | :------:   | :-------------: | ------------                                                                                                           |
+| `nextcloud_version`          | `18.0.4`   | `string`        | Which nextcloud version to install                                                                                     |
+| `nextcloud_destination`      | `/var/www` | `string`        | Where to install Nextcloud (will be installed in "{{ nextcloud_destination}}/nextcloud/" directory on your filesystem) |
+| `nextcloud_dir_user`         | `www-data` | `string`        | Which unix user should own the installed directory                                                                     |
+| `nextcloud_dir_group`        | `www-data` | `string`        | Which unix group should own the installed directory                                                                    |
+| `nextcloud_php_memory_limit` | `512M`     | `string`        | Php memory_limit setting. Default recommanded by Nextcloud is 512M.                                                    |
 
 _⚠️ Please check the php-fpm variables of the dependent [php-fpm ansible role](https://github.com/NBZ4live/ansible-php-fpm#role-variables) before running this current role. ⚠️_
+
+Most importantly check the php version you want to run and set the `php_fpm_version` variable. Here is an example configuration of the `php-fpm` dependent role which should suit most needs:
+
+```yaml
+php_fpm_version: 7.4
+
+php_fpm_pool_defaults:
+  pm: dynamic
+  pm.max_children: 10
+  pm.start_servers: 2
+  pm.min_spare_servers: 1
+  pm.max_spare_servers: 4
+php_fpm_pools:
+  - name: www
+    user: www-data
+    group: www-data
+    listen: "/run/php/php{{ php_fpm_version }}-fpm.sock"
+    listen.owner: www-data
+    listen.group: www-data
+    chdir: /var/www
+    env:
+      PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
+      TMPDIR: "/tmp"
+      TMP: "/tmp"
+      HOSTNAME: "$HOSTNAME"
+```
 
 Makefile for easier Ansible usage
 ------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,5 @@ nextcloud_version: 18.0.4
 nextcloud_destination: /var/www
 nextcloud_dir_user: www-data
 nextcloud_dir_group: www-data
+# php.ini memory_limit parameter
+nextcloud_php_memory_limit: 512M

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,8 +8,8 @@ galaxy_info:
   platforms:
   - name: Debian
     versions:
-    - jessie
     - stretch
+    - buster
   - name: Ubuntu
     versions:
     - xenial

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,3 +41,10 @@
     minute: "*/5"
     user: "{{ nextcloud_dir_user }}"
     job: "/usr/bin/php -f {{ nextcloud_destination }}/nextcloud/cron.php"
+
+- name: Configure PHP memory limit as recommended by Nextcloud
+  lineinfile:
+    path: "/etc/php/{{ php_fpm_version }}/fpm/php.ini"
+    regex: '^memory_limit ='
+    line: "memory_limit = {{ nextcloud_php_memory_limit }}"
+  when: php_fpm_version is defined


### PR DESCRIPTION
Nextcloud recommends to set the PHP memory limit to 512MB as explained
in their documentation here:

https://docs.nextcloud.com/server/18/admin_manual/installation/system_requirements.html#memory