### PR TITLE
backups: add a cron to be able to backup data + pg database

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,25 @@ Role parameters
 | `nextcloud_dir_group`        | `www-data` | `string`        | Which unix group should own the installed directory                                                                    |
 | `nextcloud_php_memory_limit` | `512M`     | `string`        | Php memory_limit setting. Default recommanded by Nextcloud is 512M.                                                    |
 
-_⚠️ Please check the php-fpm variables of the dependent [php-fpm ansible role](https://github.com/NBZ4live/ansible-php-fpm#role-variables) before running this current role. ⚠️_
+_Optional_, backup related variables:
 
-Most importantly check the php version you want to run and set the `php_fpm_version` variable. Here is an example configuration of the `php-fpm` dependent role which should suit most needs:
+| Variable                              | Default                                     | Type            | Description                                                                                             |
+| -----------------------               | :------:                                    | :-------------: | ------------                                                                                            |
+| `nextcloud_backup`                    | -                                           | `object`        | Define this object if you want to backup both the database and the data dir of your Nextcloud instance. |
+| `nextcloud_backup.destination_server` | -                                           | `string`        | Destination backup server which will receive all files (via `rsync`)                                    |
+| `nextcloud_backup.retention`          | `7`                                         | `number`        | Number of days of database backups to keep on the instance                                              |
+| `nextcloud_backup.directory`          | `nextcloud_destination + '/nextcloud/data'` | `string`        | Path of the Nextcloud data directory to backup                                                          |
+| `nextcloud_backup.pg`                 | -                                           | `object`        | Connection details to the database. See below for details of the object keys.                           |
+| `nextcloud_backup.pg.pg_dump_binary`  | -                                           | `string`        | Path of the `pg_dump` binary on the server                                                              |
+| `nextcloud_backup.pg.host`            | `localhost`                                 | `string`        | Host of the postgresql database                                                                         |
+| `nextcloud_backup.pg.port`            | `5432`                                      | `string`        | Port of the postgresql database                                                                         |
+| `nextcloud_backup.pg.dbname`          | `nextcloud`                                 | `string`        | Name of the postgresql database                                                                         |
+| `nextcloud_backup.pg.username`        | `nextcloud`                                 | `string`        | User of the postgresql database                                                                         |
+| `nextcloud_backup.pg.password`        | -                                           | `string`        | Password of the postgresql database                                                                     |
+
+_⚠️ Please also check the php-fpm variables of the dependent [php-fpm ansible role](https://github.com/NBZ4live/ansible-php-fpm#role-variables) before running this current role. ⚠️_
+
+Most importantly check the php version you want to run by setting the `php_fpm_version` variable. Here is an example configuration of the `php-fpm` dependent role which should suit most needs:
 
 ```yaml
 php_fpm_version: 7.4

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,14 @@ nextcloud_dir_user: www-data
 nextcloud_dir_group: www-data
 # php.ini memory_limit parameter
 nextcloud_php_memory_limit: 512M
+# Enable backups with the following variable
+# nextcloud_backup:
+#   destination_server: backups.example.org
+#   retention: 7
+#   pg:
+#     pg_dump_binary: /usr/lib/postgresql/12/bin/pg_dump
+#     host: localhost
+#     port: 5432
+#     dbname: nextcloud
+#     username: nextcloud
+#     password: nextcloud

--- a/tasks/backups.yml
+++ b/tasks/backups.yml
@@ -1,0 +1,22 @@
+---
+- name: Add .pgpass for backup script
+  lineinfile:
+    path: /root/.pgpass
+    mode: '600'
+    create: true
+    regex: "^{{ nextcloud_backup.pg.host|default('localhost') }}:{{ nextcloud_backup.pg.port|default(5432) }}:{{ nextcloud_backup.pg.dbname|default('nextcloud') }}:{{ nextcloud_backup.pg.username|default('nextcloud') }}"
+    line: "{{ nextcloud_backup.pg.host|default('localhost') }}:{{ nextcloud_backup.pg.port|default(5432) }}:{{ nextcloud_backup.pg.dbname|default('nextcloud') }}:{{ nextcloud_backup.pg.username|default('nextcloud') }}:{{ nextcloud_backup.pg.password }}"
+  no_log: true
+
+- name: Add a backup script to backup Data dir + Postgresql database
+  template:
+    src: backup-nextcloud.sh.j2
+    dest: /root/backup-nextcloud.sh
+    mode: '700'
+
+- name: Setup root cron to run backups every day at 3a.m
+  cron:
+    name: "Nextcloud backup cron"
+    minute: "0"
+    hour: "3"
+    job: "/root/backup-nextcloud.sh >> /var/log/backup-nexcloud.log"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,3 +48,7 @@
     regex: '^memory_limit ='
     line: "memory_limit = {{ nextcloud_php_memory_limit }}"
   when: php_fpm_version is defined
+
+- name: Setup automatic daily backups
+  include_tasks: backups.yml
+  when: nextcloud_backup is defined

--- a/templates/backup-nextcloud.sh.j2
+++ b/templates/backup-nextcloud.sh.j2
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+cd "{{ nextcloud_backup.directory | default(nextcloud_destination + '/nextcloud/data') }}" || exit 1
+
+# Backup start time
+date +"%F %T"
+
+# PG Database backup
+"{{ nextcloud_backup.pg.pg_dump_binary }}" \
+  "{{ nextcloud_backup.pg.dbname|default('nextcloud') }}" \
+  --format=c \
+  -h "{{ nextcloud_backup.pg.host|default('localhost') }}" \
+  -p "{{ nextcloud_backup.pg.port|default(5432) }}" \
+  -U "{{ nextcloud_backup.pg.username|default('nextcloud') }}" \
+  -f "nextcloud-sqlbkp_pg_$(date +"%F").bak"
+
+# Keep last 7 backups
+ls -t nextcloud-sqlbkp_* | tail -n "+{{ nextcloud_backup.retention|default(7) + 1 }}" | xargs --no-run-if-empty rm --
+
+# Data dir backup
+/usr/bin/rsync -avx "{{ nextcloud_backup.directory | default(nextcloud_destination + '/nextcloud/data') }}" "{{ nextcloud_backup.destination_server }}:/home/$(hostname)"
+
+# Backup end time
+date +"%F %T"


### PR DESCRIPTION
Most of the new feature is described in the README. By defining a
`nextcloud_backup` object with your specific configuration you will
have a daily backup script run to `pg_dump` the postgresql database
and `rsync` both the data directory and the pg dumps to the
destination server of your choice.