### PR TITLE
use package instead of apt

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,6 @@
       - php{{ php_fpm_version }}-xml
       - php{{ php_fpm_version }}-zip
     update_cache: yes
-    cache_valid_time: 3600
 
 - name: Make sure destination folder exists
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # https://docs.nextcloud.com/server/18/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 - name: Install list of prerequired php modules
-  apt:
+  package:
     name:
       - php{{ php_fpm_version }}-curl
       - php{{ php_fpm_version }}-dom


### PR DESCRIPTION
this makes this role work on centos, with `- php_fpm_version: "74-php"`

and
```
- name: "install php"
  hosts: nextcloud
  tasks:
    - package:
        name: 'dnf-utils'
        state: 'latest'


    - name: enable eremi repo
      command:
         cmd: dnf install --nogpgcheck -y http://rpms.remirepo.net/enterprise/remi-release-8.rpm

    - name: reset php
      command:

         cmd: dnf module reset php  -y

    - name: enable newest php
      command: dnf module enable php:remi-7.4 -y

    - package:
        name: 'php'
        state: 'latest'
```